### PR TITLE
Configure webpack to exclude node_modules from bundle

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -129,6 +129,11 @@ module.exports = {
       new TerserPlugin({
         parallel: true,
         terserOptions: {
+          // NestJS DI tokens and @nestjs/mongoose model names come from
+          // `Class.name`, so collapsing distinct classes to the same local
+          // identifier would cause models to clobber each other.
+          keep_classnames: true,
+          keep_fnames: true,
           format: {
             comments: false,
           },

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -4,6 +4,7 @@ const webpack = require("webpack");
 const CopyPlugin = require("copy-webpack-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
 const TsconfigPathsPlugin = require("tsconfig-paths-webpack-plugin");
+const nodeExternals = require("webpack-node-externals");
 const LicenseWebpackPlugin = require("license-webpack-plugin")
   .LicenseWebpackPlugin;
 
@@ -113,6 +114,15 @@ module.exports = {
     plugins: [new TsconfigPathsPlugin()],
     extensions: [".ts", ".tsx", ".js", ".json"],
   },
+  externalsPresets: { node: true },
+  externals: [
+    nodeExternals({
+      // Bundle aliased imports from the sibling nekocap workspace; everything
+      // else in node_modules is required at runtime so packages like
+      // `mongodb` / `whatwg-url` aren't mangled by Terser.
+      allowlist: [/^@\//],
+    }),
+  ],
   optimization: {
     minimize: true,
     minimizer: [


### PR DESCRIPTION
## Summary
Configure webpack to treat the build as a Node.js application and exclude dependencies from the bundle, while allowing aliased workspace imports to be bundled.

## Changes
- Added `webpack-node-externals` dependency to handle Node.js module externalization
- Set `externalsPresets.node` to `true` to configure webpack for Node.js environment
- Configured `externals` with `nodeExternals()` to exclude `node_modules` packages from the bundle
- Added allowlist for aliased imports (`@/`) to ensure workspace dependencies are bundled while runtime dependencies like `mongodb` and `whatwg-url` are excluded

## Implementation Details
The `nodeExternals` configuration prevents webpack from bundling Node.js runtime dependencies, which should be installed separately in the target environment. The allowlist pattern `[/^@\//]` ensures that aliased imports from the local workspace (likely from a monorepo setup) are still bundled, while keeping external packages as runtime dependencies that won't be mangled by Terser.

https://claude.ai/code/session_01CNBmnpK6aQbbQwPhrJhKqk